### PR TITLE
When calculating the Elligator 2 forward map, use -b if required.

### DIFF
--- a/extra25519/extra25519.go
+++ b/extra25519/extra25519.go
@@ -196,6 +196,13 @@ func ScalarBaseMult(publicKey, representative, privateKey *[32]byte) bool {
 	vInSquareRootImage := feBytesLE(&vBytes, &halfQMinus1Bytes)
 	edwards25519.FeCMove(&r, &r1, vInSquareRootImage)
 
+	// 5.5: Here |b| means b if b in {0, 1, ..., (q - 1)/2}, otherwise -b.
+	var rBytes [32]byte
+	edwards25519.FeToBytes(&rBytes, &r)
+	negateB := 1 & (^feBytesLE(&rBytes, &halfQMinus1Bytes))
+	edwards25519.FeNeg(&r1, &r)
+	edwards25519.FeCMove(&r, &r1, negateB)
+
 	edwards25519.FeToBytes(publicKey, &u)
 	edwards25519.FeToBytes(representative, &r)
 	return true


### PR DESCRIPTION
I have a C++ version of this code, and a user notified me of this a while ago, but I haven't gotten around to looking into it till now.

Per section 5.5 of the Elligator paper:

  "Here |b| means b if b \in {0,1,...,(q - 1)/2}, otherwise b."

The old code would sometimes return representatives that are 255 bits in length, which is incorrect (#S = (q + 1)/2).